### PR TITLE
Authencation errors with failure reason flags

### DIFF
--- a/src/Firebase.Auth.Tests/IntegrationTests.cs
+++ b/src/Firebase.Auth.Tests/IntegrationTests.cs
@@ -7,7 +7,6 @@
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System.Linq;
 
-    [TestClass]
     public class IntegrationTests
     {
         private const string ApiKey = "<YOUR API KEY>";

--- a/src/Firebase.Auth.Tests/IntegrationTests.cs
+++ b/src/Firebase.Auth.Tests/IntegrationTests.cs
@@ -7,6 +7,7 @@
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System.Linq;
 
+    [TestClass]
     public class IntegrationTests
     {
         private const string ApiKey = "<YOUR API KEY>";
@@ -51,6 +52,62 @@
 
             auth.User.Email.ShouldBeEquivalentTo(FirebaseEmail);
             auth.FirebaseToken.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [TestMethod]
+        public void Unknown_email_address_should_be_reflected_by_failure_reason()
+        {
+            using (var authProvider = new FirebaseAuthProvider(new FirebaseConfig(ApiKey)))
+            {
+                try
+                {
+                    authProvider.SignInWithEmailAndPasswordAsync("someinvalidaddressxxx@foo.com", FirebasePassword).Wait();
+                    Assert.Fail("Sign-in should fail with invalid email.");
+                }
+                catch (Exception e)
+                {
+                    var exception = (FirebaseAuthException) e.InnerException;
+                    exception.Reason.Should().Be(AuthErrorReason.UnknownEmailAddress);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void Invalid_email_address_format_should_be_reflected_by_failure_reason()
+        {
+            using (var authProvider = new FirebaseAuthProvider(new FirebaseConfig(ApiKey)))
+            {
+                try
+                {
+                    authProvider.SignInWithEmailAndPasswordAsync("notanemailaddress", FirebasePassword).Wait();
+                    Assert.Fail("Sign-in should fail with invalid email.");
+                }
+                catch (Exception e)
+                {
+                    var exception = (FirebaseAuthException)e.InnerException;
+                    exception.Reason.Should().Be(AuthErrorReason.InvalidEmailAddress);
+                }
+            }
+        }
+
+
+
+        [TestMethod]
+        public void Invalid_password_should_be_reflected_by_failure_reason()
+        {
+            using (var authProvider = new FirebaseAuthProvider(new FirebaseConfig(ApiKey)))
+            {
+                try
+                {
+                    authProvider.SignInWithEmailAndPasswordAsync(FirebaseEmail, "xx" + FirebasePassword).Wait();
+                    Assert.Fail("Sign-in should fail with invalid password.");
+                }
+                catch (Exception e)
+                {
+                    var exception = (FirebaseAuthException)e.InnerException;
+                    exception.Reason.Should().Be(AuthErrorReason.WrongPassword);
+                }
+            }
         }
 
         [TestMethod]

--- a/src/Firebase.Auth/AuthErrorReason.cs
+++ b/src/Firebase.Auth/AuthErrorReason.cs
@@ -1,0 +1,27 @@
+﻿namespace Firebase.Auth
+{
+    public enum AuthErrorReason
+    {
+        /// <summary>
+        /// Unknown error reason.
+        /// </summary>
+        Undefined,
+        /// <summary>
+        /// No user with a matching email address is registered.
+        /// </summary>
+        UnknownEmailAddress,
+        /// <summary>
+        /// The supplied ID is not a valid email address.
+        /// </summary>
+        InvalidEmailAddress,
+        /// <summary>
+        /// Wrong password.
+        /// </summary>
+        WrongPassword,
+        /// <summary>
+        /// The user was disabled and is not granted access anymore.
+        /// </summary>
+        UserDisabled
+
+    }
+}

--- a/src/Firebase.Auth/Firebase.Auth.csproj
+++ b/src/Firebase.Auth/Firebase.Auth.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EnumExtensions.cs" />
+    <Compile Include="AuthErrorReason.cs" />
     <Compile Include="FirebaseAuthLink.cs" />
     <Compile Include="FirebaseAuthException.cs" />
     <Compile Include="FirebaseConfig.cs" />

--- a/src/Firebase.Auth/FirebaseAuthException.cs
+++ b/src/Firebase.Auth/FirebaseAuthException.cs
@@ -4,12 +4,13 @@
 
     public class FirebaseAuthException : Exception
     {
-        public FirebaseAuthException(string requestUrl, string requestData, string responseData, Exception innerException) 
-            : base(GenerateExceptionMessage(requestUrl, requestData, responseData), innerException)
+        public FirebaseAuthException(string requestUrl, string requestData, string responseData, Exception innerException, AuthErrorReason reason = AuthErrorReason.Undefined) 
+            : base(GenerateExceptionMessage(requestUrl, requestData, responseData, reason), innerException)
         {
             this.RequestUrl = requestUrl;
             this.RequestData = requestData;
             this.ResponseData = responseData;
+            this.Reason = reason;
         }
 
         /// <summary>
@@ -33,9 +34,18 @@
             get;
         }
 
-        private static string GenerateExceptionMessage(string requestUrl, string requestData, string responseData)
+        /// <summary>
+        /// indicates why a login failed. If not resolved, defaults to
+        /// <see cref="AuthErrorReason.Undefined"/>.
+        /// </summary>
+        public AuthErrorReason Reason
         {
-            return $"Exception occured while authenticating.\nUrl: {requestUrl}\nRequest Data: {requestData}\nResponse: {responseData}";
+            get;
+        }
+
+        private static string GenerateExceptionMessage(string requestUrl, string requestData, string responseData, AuthErrorReason errorReason)
+        {
+            return $"Exception occured while authenticating.\nUrl: {requestUrl}\nRequest Data: {requestData}\nResponse: {responseData}\nReason: {errorReason}";
         }
     }
 }


### PR DESCRIPTION
ADD   Added AuthErrorReason flag to authentication exception in order to indicate the reason for the auth error. It's a bit of a hack (I would prefer an API that doesn't throw an exception), but won't break existing code.