### PR TITLE
Refreshing firebase token

### DIFF
--- a/src/Firebase.Auth.Tests/IntegrationTests.cs
+++ b/src/Firebase.Auth.Tests/IntegrationTests.cs
@@ -160,5 +160,21 @@
             linkedAccounts.IsRegistered.Should().BeTrue();
             linkedAccounts.Providers.Single().ShouldBeEquivalentTo(FirebaseAuthType.EmailAndPassword);
         }
+
+        [TestMethod]
+        public void RefreshAccessToken()
+        {
+            var authProvider = new FirebaseAuthProvider(new FirebaseConfig(ApiKey));
+
+            var auth = authProvider.SignInWithOAuthAsync(FirebaseAuthType.Facebook, FacebookAccessToken).Result;
+            var originalToken = auth.FirebaseToken;
+            
+            // simulate the token already expired
+            auth.Created = DateTime.MinValue;
+            
+            var freshAuth = auth.GetFreshAuthAsync().Result;
+
+            freshAuth.FirebaseToken.Should().NotBe(originalToken);
+        }
     }
 }

--- a/src/Firebase.Auth/Firebase.Auth.csproj
+++ b/src/Firebase.Auth/Firebase.Auth.csproj
@@ -42,6 +42,7 @@
   <ItemGroup>
     <Compile Include="EnumExtensions.cs" />
     <Compile Include="AuthErrorReason.cs" />
+    <Compile Include="FirebaseAuthEventArgs.cs" />
     <Compile Include="FirebaseAuthLink.cs" />
     <Compile Include="FirebaseAuthException.cs" />
     <Compile Include="FirebaseConfig.cs" />
@@ -51,6 +52,7 @@
     <Compile Include="IFirebaseAuthProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ProviderQueryResult.cs" />
+    <Compile Include="RefreshAuth.cs" />
     <Compile Include="User.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Firebase.Auth/FirebaseAuth.cs
+++ b/src/Firebase.Auth/FirebaseAuth.cs
@@ -1,12 +1,18 @@
 ﻿namespace Firebase.Auth
 {
     using Newtonsoft.Json;
+    using System;
 
     /// <summary>
     /// The firebase auth.
     /// </summary>
     public class FirebaseAuth
     {
+        public FirebaseAuth()
+        {
+            this.Created = DateTime.Now;
+        }
+
         /// <summary>
         /// Gets or sets the firebase token which can be used for authenticated queries. 
         /// </summary>
@@ -28,10 +34,19 @@
         }
 
         /// <summary>
-        /// Gets or sets the numbers of seconds until the token expires.
+        /// Gets or sets the numbers of seconds since <see cref="Created"/> when the token expires.
         /// </summary>
         [JsonProperty("expiresIn")]
         public int ExpiresIn
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets when this token was created.
+        /// </summary>
+        public DateTime Created
         {
             get;
             set;
@@ -44,6 +59,15 @@
         {
             get;
             set;
+        }
+
+        /// <summary>
+        /// Specifies whether the token already expired. 
+        /// </summary>
+        public bool IsExpired()
+        {
+            // include a small 10s window when the token is technically valid but it's a good idea to refresh it already.
+            return DateTime.Now > this.Created.AddSeconds(this.ExpiresIn - 10); 
         }
     }
 }

--- a/src/Firebase.Auth/FirebaseAuthEventArgs.cs
+++ b/src/Firebase.Auth/FirebaseAuthEventArgs.cs
@@ -1,0 +1,14 @@
+﻿namespace Firebase.Auth
+{
+    using System;
+
+    public class FirebaseAuthEventArgs : EventArgs
+    {
+        public readonly FirebaseAuth FirebaseAuth;
+
+        public FirebaseAuthEventArgs(FirebaseAuth auth)
+        {
+            this.FirebaseAuth = auth;
+        }
+    }
+}

--- a/src/Firebase.Auth/RefreshAuth.cs
+++ b/src/Firebase.Auth/RefreshAuth.cs
@@ -1,0 +1,17 @@
+﻿namespace Firebase.Auth
+{
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Serialization;
+
+    internal class RefreshAuth
+    {
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
+
+        [JsonProperty("expires_in")]
+        public int ExpiresIn { get; set; }
+
+        [JsonProperty("refresh_token")]
+        public string RefreshToken { get; set; }
+    }
+}


### PR DESCRIPTION
Adding refreshing token functionality, reflects discussion in #7 . 

There are two typical flows
1) Login -> Persist token -> Use the token (and persist again with each refresh)
2) Load persisted token -> Use the token (and persist again with each refresh)

```csharp
1)
var authProvider = new FirebaseAuthProvider(new FirebaseConfig(ApiKey));
// sign in and save the token
var auth = await authProvider.SignInWithOAuthAsync(FirebaseAuthType.Facebook, FacebookAccessToken);
SaveAuth(auth);
// save the new token each time it is refreshed
auth.FirebaseAuthRefreshed += (s, e) => SaveAuth(e.FirebaseAuth);
// use the token and let it refresh automatically (can be part of FirebaseOptions for access to Firebase DB)
await auth.GetFreshAuthAsync();

2)
var authProvider = new FirebaseAuthProvider(new FirebaseConfig(ApiKey));
// load token from storage
var auth = new FirebaseAuthLink(authProvider, LoadAuth()); // LoadAuth returns FirebaseAuth, that can be saved in local storage
// save the new token each time it is refreshed
auth.FirebaseAuthRefreshed += (s, e) => SaveAuth(e.FirebaseAuth);
// use the token and let it refresh automatically (can be part of FirebaseOptions for access to Firebase DB)
await auth.GetFreshAuthAsync();
```