### PR TITLE
Delete added to interface

### DIFF
--- a/src/Firebase.Auth/IFirebaseAuthProvider.cs
+++ b/src/Firebase.Auth/IFirebaseAuthProvider.cs
@@ -128,5 +128,11 @@
         /// <param name="auth"> The authenticated user to have its access token refreshed. </param>
         /// <returns> The <see cref="FirebaseAuthLink"/>. </returns>
         Task<FirebaseAuthLink> RefreshAuthAsync(FirebaseAuth auth);
+
+        /// <summary>
+        /// Deletes the user with a recent Firebase Token.
+        /// </summary>
+        /// <param name="token"> Recent Firebase Token. </param>
+        Task DeleteUser(string firebaseToken);
     }
 }


### PR DESCRIPTION
Firebase authentication delete was not really testable, since the relatively newly added delete method had not been propagated to the IAuthProvider interface. Fixed this.