### PR TITLE
Add public API to unlink providers

### DIFF
--- a/src/Firebase.Auth/FirebaseAuthLink.cs
+++ b/src/Firebase.Auth/FirebaseAuthLink.cs
@@ -41,7 +41,7 @@
         }
 
         /// <summary>
-        /// Links the this user with and account from a third party provider.
+        /// Links the user with an account from a third party provider.
         /// </summary> 
         /// <param name="authType"> The auth type.  </param>
         /// <param name="oauthAccessToken"> The access token retrieved from login provider of your choice. </param>
@@ -49,6 +49,20 @@
         public async Task<FirebaseAuthLink> LinkToAsync(FirebaseAuthType authType, string oauthAccessToken)
         {
             var auth = await this.AuthProvider.LinkAccountsAsync(this, authType, oauthAccessToken).ConfigureAwait(false);
+
+            this.CopyPropertiesLocally(auth.AuthProvider, auth);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Unlinks the user from the given <see cref="authType"/> (provider).
+        /// </summary> 
+        /// <param name="authType"> The auth type.  </param>
+        /// <returns> The <see cref="FirebaseAuthLink"/>.  </returns>
+        public async Task<FirebaseAuthLink> UnlinkFromAsync(FirebaseAuthType authType)
+        {
+            var auth = await this.AuthProvider.UnlinkAccountsAsync(this, authType).ConfigureAwait(false);
 
             this.CopyPropertiesLocally(auth.AuthProvider, auth);
 

--- a/src/Firebase.Auth/FirebaseAuthProvider.cs
+++ b/src/Firebase.Auth/FirebaseAuthProvider.cs
@@ -215,7 +215,7 @@
         }
 
         /// <summary>
-        /// Links the authenticated user represented by <see cref="auth"/> with an email and password. 
+        /// Links the given <see cref="firebaseToken"/> with an email and password. 
         /// </summary>
         /// <param name="firebaseToken"> The FirebaseToken (idToken) of an authenticated user. </param>
         /// <param name="email"> The email. </param>
@@ -241,7 +241,7 @@
         }
 
         /// <summary>
-        /// Links the authenticated user represented by <see cref="auth"/> with and account from a third party provider.
+        /// Links the given <see cref="firebaseToken"/> with an account from a third party provider.
         /// </summary>
         /// <param name="firebaseToken"> The FirebaseToken (idToken) of an authenticated user. </param>
         /// <param name="authType"> The auth type.  </param>
@@ -256,7 +256,7 @@
         }
 
         /// <summary>
-        /// Links the authenticated user represented by <see cref="auth"/> with and account from a third party provider.
+        /// Links the authenticated user represented by <see cref="auth"/> with an account from a third party provider.
         /// </summary>
         /// <param name="auth"> The auth. </param>
         /// <param name="authType"> The auth type.  </param>
@@ -265,6 +265,40 @@
         public async Task<FirebaseAuthLink> LinkAccountsAsync(FirebaseAuth auth, FirebaseAuthType authType, string oauthAccessToken)
         {
             return await this.LinkAccountsAsync(auth.FirebaseToken, authType, oauthAccessToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Unlinks the given <see cref="authType"/> from the account associated with <see cref="firebaseToken"/>.
+        /// </summary>
+        /// <param name="firebaseToken"> The FirebaseToken (idToken) of an authenticated user. </param>
+        /// <param name="authType"> The auth type.  </param>
+        /// <returns> The <see cref="FirebaseAuthLink"/>.  </returns>
+        public async Task<FirebaseAuthLink> UnlinkAccountsAsync(string firebaseToken, FirebaseAuthType authType)
+        {
+            string providerId = null;
+            if (authType == FirebaseAuthType.EmailAndPassword)
+            {
+                providerId = authType.ToEnumString();
+            }
+            else
+            {
+                providerId = this.GetProviderId(authType);
+            }
+
+            var content = $"{{\"idToken\":\"{firebaseToken}\",\"deleteProvider\":[\"{providerId}\"]}}";
+
+            return await this.ExecuteWithPostContentAsync(GoogleSetAccountUrl, content).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Unlinks the given <see cref="authType"/> from the authenticated user represented by <see cref="auth"/>.
+        /// </summary>
+        /// <param name="auth"> The auth. </param>
+        /// <param name="authType"> The auth type.  </param>
+        /// <returns> The <see cref="FirebaseAuthLink"/>.  </returns>
+        public async Task<FirebaseAuthLink> UnlinkAccountsAsync(FirebaseAuth auth, FirebaseAuthType authType)
+        {
+            return await this.UnlinkAccountsAsync(auth.FirebaseToken, authType).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Firebase.Auth/IFirebaseAuthProvider.cs
+++ b/src/Firebase.Auth/IFirebaseAuthProvider.cs
@@ -90,6 +90,22 @@
         Task<FirebaseAuthLink> LinkAccountsAsync(string firebaseToken, FirebaseAuthType authType, string oauthAccessToken);
 
         /// <summary>
+        /// Unlinks the given <see cref="authType"/> from the account associated with <see cref="firebaseToken"/>.
+        /// </summary>
+        /// <param name="firebaseToken"> The FirebaseToken (idToken) of an authenticated user. </param>
+        /// <param name="authType"> The auth type.  </param>
+        /// <returns> The <see cref="FirebaseAuthLink"/>.  </returns>
+        Task<FirebaseAuthLink> UnlinkAccountsAsync(string firebaseToken, FirebaseAuthType authType);
+
+        /// <summary>
+        /// Unlinks the given <see cref="authType"/> from the authenticated user represented by <see cref="auth"/>.
+        /// </summary>
+        /// <param name="auth"> The auth. </param>
+        /// <param name="authType"> The auth type.  </param>
+        /// <returns> The <see cref="FirebaseAuthLink"/>.  </returns>
+        Task<FirebaseAuthLink> UnlinkAccountsAsync(FirebaseAuth auth, FirebaseAuthType authType);
+
+        /// <summary>
         /// Gets a list of accounts linked to given email.
         /// </summary>
         /// <param name="email"> Email address. </param>


### PR DESCRIPTION
Based on the REST API documentation: https://firebase.google.com/docs/reference/rest/auth/#section-unlink-provider