### PR TITLE
fetch user details after each successful sign in

### DIFF
--- a/src/Firebase.Auth/Firebase.Auth.csproj
+++ b/src/Firebase.Auth/Firebase.Auth.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.1</TargetFramework>
     <PackageId>FirebaseAuthentication.net</PackageId>
-    <PackageVersion>3.4.0</PackageVersion>
+    <PackageVersion>3.5.0</PackageVersion>
     <Authors>Step Up Labs, Inc.</Authors>
     <Description>Firebase authentication library. It can generate Firebase auth token based on given OAuth token (issued by Google, Facebook...). This Firebase token can then be used with REST queries against Firebase endpoints. </Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/Firebase.Auth/FirebaseAuthProvider.cs
+++ b/src/Firebase.Auth/FirebaseAuthProvider.cs
@@ -102,7 +102,9 @@
             var providerId = this.GetProviderId(authType);
             var content = $"{{\"postBody\":\"access_token={oauthAccessToken}&providerId={providerId}\",\"requestUri\":\"http://localhost\",\"returnSecureToken\":true}}";
 
-            return await this.ExecuteWithPostContentAsync(GoogleIdentityUrl, content).ConfigureAwait(false);
+            FirebaseAuthLink firebaseAuthLink = await this.ExecuteWithPostContentAsync(GoogleIdentityUrl, content).ConfigureAwait(false);
+            firebaseAuthLink.User = await this.GetUserAsync(firebaseAuthLink.FirebaseToken).ConfigureAwait(false);
+            return firebaseAuthLink;
         }
 
         /// <summary>
@@ -117,7 +119,9 @@
             var providerId = this.GetProviderId(FirebaseAuthType.Twitter);
             var content = $"{{\"postBody\":\"access_token={oauthAccessToken}&oauth_token_secret={oauthTokenSecret}&providerId={providerId}\",\"requestUri\":\"http://localhost\",\"returnSecureToken\":true}}";
             
-            return await this.ExecuteWithPostContentAsync(GoogleIdentityUrl, content).ConfigureAwait(false);
+            FirebaseAuthLink firebaseAuthLink = await this.ExecuteWithPostContentAsync(GoogleIdentityUrl, content).ConfigureAwait(false);
+            firebaseAuthLink.User = await this.GetUserAsync(firebaseAuthLink.FirebaseToken).ConfigureAwait(false);
+            return firebaseAuthLink;
         }
 
         /// <summary>
@@ -131,7 +135,9 @@
             var providerId = this.GetProviderId(FirebaseAuthType.Google);
             var content = $"{{\"postBody\":\"id_token={idToken}&providerId={providerId}\",\"requestUri\":\"http://localhost\",\"returnSecureToken\":true}}";
 
-            return await this.ExecuteWithPostContentAsync(GoogleIdentityUrl, content).ConfigureAwait(false);
+            FirebaseAuthLink firebaseAuthLink = await this.ExecuteWithPostContentAsync(GoogleIdentityUrl, content).ConfigureAwait(false);
+            firebaseAuthLink.User = await this.GetUserAsync(firebaseAuthLink.FirebaseToken).ConfigureAwait(false);
+            return firebaseAuthLink;
         }
 
         /// <summary>
@@ -164,7 +170,9 @@
 
             sb.Append("\"returnSecureToken\":true}}");
 
-            return await ExecuteWithPostContentAsync(GooglePasswordUrl, sb.ToString()).ConfigureAwait(false);
+            FirebaseAuthLink firebaseAuthLink = await this.ExecuteWithPostContentAsync(GooglePasswordUrl, sb.ToString()).ConfigureAwait(false);
+            firebaseAuthLink.User = await this.GetUserAsync(firebaseAuthLink.FirebaseToken).ConfigureAwait(false);
+            return firebaseAuthLink;
         }
         
         /// <summary>


### PR DESCRIPTION
Fetching user details immediately after a successful sign in is already done for `SignInWithCustomTokenAsync`:
https://github.com/step-up-labs/firebase-authentication-dotnet/blob/f75ec11cb7df2d907c0f22f1e6b01dbc034eb90e/src/Firebase.Auth/FirebaseAuthProvider.cs#L51-L57

This PR adds similar functionality to other sign in methods:
- `SignInWithOAuthAsync`
- `SignInWithOAuthTwitterTokenAsync`
- `SignInWithGoogleIdTokenAsync`
- `SignInWithGoogleIdTokenAsync`
- `SignInWithEmailAndPasswordAsync`

Fetching user details is not done for `SignInAnonymouslyAsync` as I believer each anonymous login creates a new user and there'd be no user details to fetch after such login.

Closes #21.