### PR TITLE
Adds support for auth emulator

### DIFF
--- a/src/Firebase.Auth/FirebaseConfig.cs
+++ b/src/Firebase.Auth/FirebaseConfig.cs
@@ -9,15 +9,37 @@
         /// Initializes a new instance of the <see cref="FirebaseConfig"/> class.
         /// </summary>
         /// <param name="apiKey"> The api key of your Firebase app. </param>
-        public FirebaseConfig(string apiKey)
+        /// <param name="usesEmulator"> If the emulator is being used. Default is false. </param>
+        /// <param name="emulatorPort"> What port the emulator is using. Default is 9099. </param>
+        public FirebaseConfig(string apiKey, bool usesEmulator = false, int emulatorPort = 9099)
         {
             this.ApiKey = apiKey;
+            this.UsesEmulator = usesEmulator;
+            this.EmulatorPort = emulatorPort;
         }
 
         /// <summary>
         /// Gets or sets the api key of your Firebase app. 
         /// </summary>
-        public string ApiKey 
+        public string ApiKey
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets whether the emulator is used or not. 
+        /// </summary>
+        public bool UsesEmulator
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the port the emulator uses. 
+        /// </summary>
+        public int EmulatorPort
         {
             get;
             set;


### PR DESCRIPTION
The Authentication Emulator allows you to quickly and safely test new changes to how your app handles authentication. I saw this library had no way to connect to the emulator, so I made an issue last year asking about it (#160). It became stale, but since then I've learned how to add it in myself.

By replacing `https://` with `http://localhost:9099/` in the API calls, we are able to use this library for the emulator with no other changes.

Initialization looks like this:
`var authProvider = new FirebaseAuthProvider(new FirebaseConfig(ApiKey, true));`
The only difference is there is now a new boolean parameter asking if you would like to use the emulator or not. It is optional and defaults to false so there will be no breaking changes when users update. This boolean will allow easy switching between dev environments that use the emulator vs prod environments that do not. A third parameter allows you set the port if you have decided to not use the default port of 9099