### PR TITLE
Updated 'AppleProvider.cs' for supporting other TokenTypes than just AccessToken

### DIFF
--- a/src/Auth/Providers/AppleProvider.cs
+++ b/src/Auth/Providers/AppleProvider.cs
@@ -4,7 +4,8 @@
     {
         public const string DefaultEmailScope = "email";
 
-        public AppleProvider() {
+        public AppleProvider()
+        {
             this.AddScopes(DefaultEmailScope);
         }
 

--- a/src/Auth/Providers/AppleProvider.cs
+++ b/src/Auth/Providers/AppleProvider.cs
@@ -4,12 +4,11 @@
     {
         public const string DefaultEmailScope = "email";
 
-        public AppleProvider()
-        {
+        public AppleProvider() {
             this.AddScopes(DefaultEmailScope);
         }
 
-        public static AuthCredential GetCredential(string accessToken) => GetCredential(FirebaseProviderType.Apple, accessToken, OAuthCredentialTokenType.AccessToken);
+        public static AuthCredential GetCredential(string Token, OAuthCredentialTokenType TokenType) => GetCredential(FirebaseProviderType.Apple, Token, TokenType);
 
         public override FirebaseProviderType ProviderType => FirebaseProviderType.Apple;
 


### PR DESCRIPTION
A small change to allow the use of other tokens than AccessToken with the AppleProvider