### PR TITLE
Changes to use the library in .Net 7 winforms app

### DIFF
--- a/src/Auth.UI.WPF/Auth.UI.WPF.csproj
+++ b/src/Auth.UI.WPF/Auth.UI.WPF.csproj
@@ -26,6 +26,7 @@ The library provides a drop-in auth solution that handles the flows for signing 
     <AssemblyName>Firebase.Auth.UI.WPF</AssemblyName>
     <RootNamespace>Firebase.Auth.UI</RootNamespace>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
 

--- a/src/Auth.UI.WPF/Auth.UI.WPF.csproj
+++ b/src/Auth.UI.WPF/Auth.UI.WPF.csproj
@@ -33,12 +33,12 @@ The library provides a drop-in auth solution that handles the flows for signing 
   <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">
     <ItemGroup>
       <!-- Filter out unnecessary files -->
-      <_ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('PrivateAssets', 'All'))"/>
+      <_ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')-&gt;WithMetadataValue('PrivateAssets', 'All'))" />
     </ItemGroup>
 
     <ItemGroup>
       <!-- Add file to package with consideration of sub folder. If empty, the root folder is chosen. -->
-      <BuildOutputInPackage Include="@(_ReferenceCopyLocalPaths)" TargetPath="%(_ReferenceCopyLocalPaths.DestinationSubDirectory)"/>
+      <BuildOutputInPackage Include="@(_ReferenceCopyLocalPaths)" TargetPath="%(_ReferenceCopyLocalPaths.DestinationSubDirectory)" />
     </ItemGroup>
   </Target>
 
@@ -51,9 +51,9 @@ The library provides a drop-in auth solution that handles the flows for signing 
     <Resource Include="..\Auth.UI\Assets\mail.png" Link="Assets\mail.png" />
     <Resource Include="..\Auth.UI\Assets\microsoft.png" Link="Assets\microsoft.png" />
     <Resource Include="..\Auth.UI\Assets\twitter.png" Link="Assets\twitter.png" />
-    <None Include="..\Auth.UI\Assets\firebase.png" Link="Assets\firebase.png" Pack="true" PackagePath=""/>
-    <None Include="..\..\LICENSE.txt" Link="Assets\LICENSE.txt" Pack="true" PackagePath=""/>
-    <None Include="..\..\README.md" Link="Assets\README.md" Pack="true" PackagePath=""/>
+    <None Include="..\Auth.UI\Assets\firebase.png" Link="Assets\firebase.png" Pack="true" PackagePath="" />
+    <None Include="..\..\LICENSE.txt" Link="Assets\LICENSE.txt" Pack="true" PackagePath="" />
+    <None Include="..\..\README.md" Link="Assets\README.md" Pack="true" PackagePath="" />
     <None Include="tools\VisualStudioToolsManifest.xml" Pack="true" PackagePath="tools" />
   </ItemGroup>
 
@@ -63,7 +63,7 @@ The library provides a drop-in auth solution that handles the flows for signing 
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1462.37" />
+	<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1661.34" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Auth.UI.WPF/WebAuthenticationBroker.cs
+++ b/src/Auth.UI.WPF/WebAuthenticationBroker.cs
@@ -1,16 +1,18 @@
 ﻿using Firebase.Auth.UI.Converters;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Forms;
 
 namespace Firebase.Auth.UI
 {
-    internal static class WebAuthenticationBroker
+    public static class WebAuthenticationBroker
     {
-        public static Task<string> AuthenticateAsync(Window owner, FirebaseProviderType provider, string uri, string redirectUri)
+        public static Task<string> AuthenticateAsync(object owner, FirebaseProviderType provider, string uri, string redirectUri)
         {
             var tcs = new TaskCompletionSource<string>();
 
-            Application.Current.Dispatcher.Invoke(() =>
+            System.Windows.Application.Current.Dispatcher.Invoke(() =>
             {
                 var window = new WebAuthenticationBrokerWindow();
                 window.WebView.NavigationCompleted += (s, e) =>
@@ -25,7 +27,12 @@ namespace Firebase.Auth.UI
                 };
                 window.Title = ProviderToTitleConverter.Convert(provider);
                 window.WebView.Loaded += (s, e) => window.WebView.Source = new System.Uri(uri);
-                window.Owner = owner;
+                if (owner is Window owner_window) window.Owner = owner_window;
+                else if (owner is Form owner_form)
+                {
+                    WindowInteropHelper helper = new WindowInteropHelper(window);
+                    helper.Owner = owner_form.Handle;
+                }
                 if (!(window.ShowDialog() ?? false))
                 {
                     tcs.SetResult(null);

--- a/src/Auth/Auth.csproj
+++ b/src/Auth/Auth.csproj
@@ -42,7 +42,7 @@ FirebaseUI is supported by platform-specific libraries:
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Auth/FirebaseAuthClient.cs
+++ b/src/Auth/FirebaseAuthClient.cs
@@ -204,12 +204,12 @@ namespace Firebase.Auth
             value?.Invoke(this, new UserEventArgs(user));
         }
 
-        private void SaveToken(User user)
+        public void SaveToken(User user)
         {
             this.config.UserManager.SaveNewUser(user);
         }
 
-        private async Task CheckAuthDomain()
+        public async Task CheckAuthDomain()
         {
             if (this.domainChecked)
             {

--- a/src/Auth/Providers/OAuthProvider.cs
+++ b/src/Auth/Providers/OAuthProvider.cs
@@ -58,7 +58,7 @@ namespace Firebase.Auth.Providers
                 response.PendingToken == null ? OAuthCredentialTokenType.AccessToken : OAuthCredentialTokenType.PendingToken);
         }
 
-        internal virtual async Task<OAuthContinuation> SignInAsync()
+        public virtual async Task<OAuthContinuation> SignInAsync()
         {
             if (this.LocaleParameterName != null && !this.parameters.ContainsKey(this.LocaleParameterName))
             {


### PR DESCRIPTION
Made some changes to get your (really useful) auth working for me in a .Net 7 winforms app. 

Changes:
- made some classes more accessible to hook in from a winform - didn't have access to necessary methods. 
- A few library updates, but they weren't essential. 
- adds the <UseWindowsForms>true</UseWindowsForms> to the project file in WPF. This shouldn't affect WPF at all
- change parameter type to WebAuthenticationBroker AuthenticateAsync to support management by a winform as well as WPF

It would be great if you could incorporate this into your published library. Happy to discuss.