### PR TITLE
Add Invalid_Login_Credential case

### DIFF
--- a/samples/UWP/Auth.UWP.Sample.csproj
+++ b/samples/UWP/Auth.UWP.Sample.csproj
@@ -18,7 +18,7 @@
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
     <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
-    <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.22000.0</TargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Auth/FirebaseFailureParser.cs
+++ b/src/Auth/FirebaseFailureParser.cs
@@ -63,6 +63,10 @@ namespace Firebase.Auth
                     //possible errors from Email/Password Signin
                     case "INVALID_PASSWORD":
                         return AuthErrorReason.WrongPassword;
+
+                    case "INVALID_LOGIN_CREDENTIALS":
+                        return AuthErrorReason.WrongPassword;
+
                     case "EMAIL_NOT_FOUND":
                         return AuthErrorReason.UnknownEmailAddress;
                     case "USER_DISABLED":


### PR DESCRIPTION
Response when the wrong pass is provided: 

>             Response: {
>               "error": {
>                 "code": 400,
>                 "message": "INVALID_LOGIN_CREDENTIALS",
>                 "errors": [
>                   {
>                     "message": "INVALID_LOGIN_CREDENTIALS",
>                     "domain": "global",
>                     "reason": "invalid"
>                   }
>                 ]
>               }
>             }

I have added this case to parser