### PR TITLE
Winui3 unpackaged fix

### DIFF
--- a/samples/WinUI3/App.xaml.cs
+++ b/samples/WinUI3/App.xaml.cs
@@ -55,7 +55,10 @@ namespace Auth.WinUI3.Sample
                 {
                     if (e.User == null)
                     {
-                        await FirebaseUI.Instance.Client.SignInAnonymouslyAsync();
+                        if (FirebaseUI.Instance.Config.IsAnonymousAllowed)
+                        {
+                            await FirebaseUI.Instance.Client.SignInAnonymouslyAsync();
+                        }
                         (Window.Content as Frame).Navigate(typeof(LoginPage));
                     }
                     else if (e.User.IsAnonymous)

--- a/src/Auth.UI.WinUI3/Auth.UI.WinUI3.csproj
+++ b/src/Auth.UI.WinUI3/Auth.UI.WinUI3.csproj
@@ -36,12 +36,12 @@ The library provides a drop-in auth solution that handles the flows for signing 
   <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">
     <ItemGroup>
       <!-- Filter out unnecessary files -->
-      <_ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('PrivateAssets', 'All'))"/>
+      <_ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')-&gt;WithMetadataValue('PrivateAssets', 'All'))" />
     </ItemGroup>
 
     <ItemGroup>
       <!-- Add file to package with consideration of sub folder. If empty, the root folder is chosen. -->
-      <BuildOutputInPackage Include="@(_ReferenceCopyLocalPaths)" TargetPath="%(_ReferenceCopyLocalPaths.DestinationSubDirectory)"/>
+      <BuildOutputInPackage Include="@(_ReferenceCopyLocalPaths)" TargetPath="%(_ReferenceCopyLocalPaths.DestinationSubDirectory)" />
     </ItemGroup>
   </Target>
 	

--- a/src/Auth.UI.WinUI3/Helpers/Json.cs
+++ b/src/Auth.UI.WinUI3/Helpers/Json.cs
@@ -1,0 +1,31 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+
+namespace Firebase.Auth.UI.Helpers
+{
+    public static class Json
+    {
+        public static async Task<T> ToObjectAsync<T>(string value)
+        {
+            return await Task.Run<T>(() =>
+            {
+                return JsonConvert.DeserializeObject<T>(value);
+            }).ConfigureAwait(false);
+        }
+
+        public static async Task<string> StringifyAsync(object value)
+        {
+            return await Task.Run<string>(() =>
+            {
+                return JsonConvert.SerializeObject(value);
+            }).ConfigureAwait(false);
+        }
+    }
+
+}
+

--- a/src/Auth.UI.WinUI3/Helpers/RuntimeHelper.cs
+++ b/src/Auth.UI.WinUI3/Helpers/RuntimeHelper.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Firebase.Auth.UI.Helpers
+{
+    public class RuntimeHelper
+    {
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern int GetCurrentPackageFullName(ref int packageFullNameLength, StringBuilder packageFullName);
+
+        public static bool IsMSIX
+        {
+            get
+            {
+                var length = 0;
+
+                return GetCurrentPackageFullName(ref length, null) != 15700L;
+            }
+        }
+    }
+
+}

--- a/src/Auth.UI.WinUI3/Repository/LocalSettingsWrapper.cs
+++ b/src/Auth.UI.WinUI3/Repository/LocalSettingsWrapper.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Storage;
+
+using Windows.ApplicationModel;
+using Firebase.Auth.UI.Helpers;
+
+
+namespace Firebase.Auth.UI.Repository
+{
+    internal class LocalSettingsWrapper
+    {
+        private const string _defaultApplicationDataFolder = "AutoVid/ApplicationData";
+        private const string _defaultLocalSettingsFile = "LocalSettings.json";
+
+
+        private readonly string _localApplicationData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        private readonly string _applicationDataFolder;
+        private readonly string _localsettingsFile;
+
+
+
+
+        private IDictionary<string, object> _settings;
+
+        private bool _isInitialized;
+
+        //make as singletion
+        private static LocalSettingsWrapper _instance;
+        public static LocalSettingsWrapper Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new LocalSettingsWrapper();
+                }
+
+                return _instance;
+            }
+        }
+        public LocalSettingsWrapper()
+        {
+            _applicationDataFolder = System.IO.Path.Combine(_localApplicationData, _defaultApplicationDataFolder);
+            _localsettingsFile = _defaultLocalSettingsFile;
+
+            _settings = new Dictionary<string, object>();
+        }
+
+        public bool Exists(string key)
+        {
+            if (RuntimeHelper.IsMSIX)
+            {
+                return ApplicationData.Current.LocalSettings.Values.ContainsKey(key);
+            }
+            else
+            {
+                return _settings.ContainsKey(key);
+            }
+        }
+
+        private async Task InitializeAsync()
+        {
+            if (!_isInitialized)
+            {
+                //_settings = await Task.Run(() => _fileService.Read<IDictionary<string, object>>(_applicationDataFolder, _localsettingsFile)) ?? new Dictionary<string, object>();
+
+                string filepath = System.IO.Path.Combine(_applicationDataFolder, _localsettingsFile);
+                if (System.IO.File.Exists(filepath))
+                {
+                    string content = await System.IO.File.ReadAllTextAsync(filepath);
+                    _settings = await Json.ToObjectAsync<IDictionary<string, object>>(content).ConfigureAwait(false);
+                }
+                else
+                {
+                    _settings = new Dictionary<string, object>();
+                }
+
+                _isInitialized = true;
+            }
+        }
+
+        public async Task<T> ReadSettingAsync<T>(string key)
+        {
+            if (RuntimeHelper.IsMSIX)
+            {
+                if (ApplicationData.Current.LocalSettings.Values.TryGetValue(key, out var obj))
+                {
+                    return await Json.ToObjectAsync<T>((string)obj).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                await InitializeAsync();
+
+                if (_settings != null && _settings.TryGetValue(key, out var obj))
+                {
+                    return await Json.ToObjectAsync<T>((string)obj).ConfigureAwait(false);
+                }
+            }
+
+            return default;
+        }
+
+        public async Task SaveSettingAsync<T>(string key, T value)
+        {
+            if (RuntimeHelper.IsMSIX)
+            {
+                ApplicationData.Current.LocalSettings.Values[key] = await Json.StringifyAsync(value).ConfigureAwait(false);
+            }
+            else
+            {
+                await InitializeAsync();
+
+                _settings[key] = await Json.StringifyAsync(value).ConfigureAwait(false);
+
+                string filepath = System.IO.Path.Combine(_applicationDataFolder, _localsettingsFile);
+                await System.IO.File.WriteAllTextAsync(filepath, await Json.StringifyAsync(_settings)).ConfigureAwait(false);
+
+
+                //await Task.Run(() => _fileService.Save(_applicationDataFolder, _localsettingsFile, _settings));
+            }
+        }
+    }
+
+}

--- a/src/Auth.UI.WinUI3/Repository/LocalSettingsWrapper.cs
+++ b/src/Auth.UI.WinUI3/Repository/LocalSettingsWrapper.cs
@@ -9,6 +9,7 @@ using Windows.Storage;
 using Windows.ApplicationModel;
 using Firebase.Auth.UI.Helpers;
 using System.Reflection;
+using System.Diagnostics;
 
 
 namespace Firebase.Auth.UI.Repository
@@ -40,8 +41,11 @@ namespace Firebase.Auth.UI.Repository
         }
         public LocalSettingsWrapper()
         {
-            var appName = Assembly.GetExecutingAssembly().GetName().Name;
-            _applicationDataFolder = System.IO.Path.Combine(_localApplicationData, $"{appName}/ApplicationData");
+            var process = Process.GetCurrentProcess();
+            string mainExecutablePath = process.MainModule.FileName;
+            string appName = System.IO.Path.GetFileNameWithoutExtension(mainExecutablePath);
+
+            _applicationDataFolder = System.IO.Path.Combine(_localApplicationData, $"{appName}Data");
             _localsettingsFile = _defaultLocalSettingsFile;
 
             _settings = new Dictionary<string, object>();
@@ -113,6 +117,10 @@ namespace Firebase.Auth.UI.Repository
                 await InitializeAsync();
 
                 _settings[key] = await Json.StringifyAsync(value).ConfigureAwait(false);
+                if (System.IO.Directory.Exists(_applicationDataFolder) == false)
+                {
+                    System.IO.Directory.CreateDirectory(_applicationDataFolder);
+                }
 
                 string filepath = System.IO.Path.Combine(_applicationDataFolder, _localsettingsFile);
                 await System.IO.File.WriteAllTextAsync(filepath, await Json.StringifyAsync(_settings)).ConfigureAwait(false);

--- a/src/Auth.UI.WinUI3/Repository/LocalSettingsWrapper.cs
+++ b/src/Auth.UI.WinUI3/Repository/LocalSettingsWrapper.cs
@@ -72,7 +72,7 @@ namespace Firebase.Auth.UI.Repository
                 string filepath = System.IO.Path.Combine(_applicationDataFolder, _localsettingsFile);
                 if (System.IO.File.Exists(filepath))
                 {
-                    string content = await System.IO.File.ReadAllTextAsync(filepath);
+                    string content = await System.IO.File.ReadAllTextAsync(filepath).ConfigureAwait(false);
                     _settings = await Json.ToObjectAsync<IDictionary<string, object>>(content).ConfigureAwait(false);
                 }
                 else
@@ -95,7 +95,7 @@ namespace Firebase.Auth.UI.Repository
             }
             else
             {
-                await InitializeAsync();
+                await InitializeAsync().ConfigureAwait(false);
 
                 if (_settings != null && _settings.TryGetValue(key, out var obj))
                 {
@@ -114,7 +114,7 @@ namespace Firebase.Auth.UI.Repository
             }
             else
             {
-                await InitializeAsync();
+                await InitializeAsync().ConfigureAwait(false);
 
                 _settings[key] = await Json.StringifyAsync(value).ConfigureAwait(false);
                 if (System.IO.Directory.Exists(_applicationDataFolder) == false)

--- a/src/Auth.UI.WinUI3/Repository/LocalSettingsWrapper.cs
+++ b/src/Auth.UI.WinUI3/Repository/LocalSettingsWrapper.cs
@@ -8,22 +8,17 @@ using Windows.Storage;
 
 using Windows.ApplicationModel;
 using Firebase.Auth.UI.Helpers;
+using System.Reflection;
 
 
 namespace Firebase.Auth.UI.Repository
 {
     internal class LocalSettingsWrapper
     {
-        private const string _defaultApplicationDataFolder = "AutoVid/ApplicationData";
         private const string _defaultLocalSettingsFile = "LocalSettings.json";
-
-
         private readonly string _localApplicationData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         private readonly string _applicationDataFolder;
         private readonly string _localsettingsFile;
-
-
-
 
         private IDictionary<string, object> _settings;
 
@@ -45,7 +40,8 @@ namespace Firebase.Auth.UI.Repository
         }
         public LocalSettingsWrapper()
         {
-            _applicationDataFolder = System.IO.Path.Combine(_localApplicationData, _defaultApplicationDataFolder);
+            var appName = Assembly.GetExecutingAssembly().GetName().Name;
+            _applicationDataFolder = System.IO.Path.Combine(_localApplicationData, $"{appName}/ApplicationData");
             _localsettingsFile = _defaultLocalSettingsFile;
 
             _settings = new Dictionary<string, object>();

--- a/src/Auth.UI.WinUI3/Repository/StorageRepository.cs
+++ b/src/Auth.UI.WinUI3/Repository/StorageRepository.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Firebase.Auth.UI.Repository;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System.Threading.Tasks;
 using Windows.Storage;
@@ -10,39 +11,46 @@ namespace Firebase.Auth.Repository
         private const string UserStorageKey = "FirebaseUser";
         private const string CredentialStorageKey = "FirebaseCredential";
 
-        private readonly ApplicationDataContainer settings;
+        //private readonly ApplicationDataContainer settings;
         private readonly JsonSerializerSettings options;
 
         public StorageRepository()
         {
-            this.settings = ApplicationData.Current.LocalSettings;
+            //this.settings = ApplicationData.Current.LocalSettings;
             this.options = new JsonSerializerSettings();
             this.options.Converters.Add(new StringEnumConverter());
         }
 
         public void DeleteUser()
         {
-            this.settings.Values[UserStorageKey] = null;
-            this.settings.Values[CredentialStorageKey] = null;
+            LocalSettingsWrapper.Instance.SaveSettingAsync<string>(UserStorageKey, null).Wait();
+            LocalSettingsWrapper.Instance.SaveSettingAsync<string>(CredentialStorageKey, null).Wait();
+            //this.settings.Values[UserStorageKey] = null;
+            //this.settings.Values[CredentialStorageKey] = null;
         }
 
         public (UserInfo userInfo, FirebaseCredential credential) ReadUser()
         {
-            var info = JsonConvert.DeserializeObject<UserInfo>(this.settings.Values[UserStorageKey].ToString(), this.options);
-            var credential = JsonConvert.DeserializeObject<FirebaseCredential>(this.settings.Values[CredentialStorageKey].ToString(), this.options);
+            string storageKey = LocalSettingsWrapper.Instance.ReadSettingAsync<string>(UserStorageKey).Result;
+            string credentialKey = LocalSettingsWrapper.Instance.ReadSettingAsync<string>(CredentialStorageKey).Result;
+            var info = JsonConvert.DeserializeObject<UserInfo>(storageKey, this.options);
+            var credential = JsonConvert.DeserializeObject<FirebaseCredential>(credentialKey, this.options);
 
-            return (info, credential); 
+            return (info, credential);
         }
 
         public void SaveUser(User user)
         {
-            this.settings.Values[UserStorageKey] = JsonConvert.SerializeObject(user.Info, this.options);
-            this.settings.Values[CredentialStorageKey] = JsonConvert.SerializeObject(user.Credential, this.options);
+            LocalSettingsWrapper.Instance.SaveSettingAsync<string>(UserStorageKey, JsonConvert.SerializeObject(user.Info, this.options)).Wait();
+            LocalSettingsWrapper.Instance.SaveSettingAsync<string>(CredentialStorageKey, JsonConvert.SerializeObject(user.Credential, this.options)).Wait();
+            //this.settings.Values[UserStorageKey] = JsonConvert.SerializeObject(user.Info, this.options);
+            //this.settings.Values[CredentialStorageKey] = JsonConvert.SerializeObject(user.Credential, this.options);
         }
 
         public bool UserExists()
         {
-            return this.settings.Values.ContainsKey(UserStorageKey);
+            return LocalSettingsWrapper.Instance.Exists(UserStorageKey);
+            //return this.settings.Values.ContainsKey(UserStorageKey);
         }
     }
 }

--- a/src/Auth.UI.WinUI3/Repository/StorageRepository.cs
+++ b/src/Auth.UI.WinUI3/Repository/StorageRepository.cs
@@ -33,6 +33,10 @@ namespace Firebase.Auth.Repository
         {
             string storageKey = LocalSettingsWrapper.Instance.ReadSettingAsync<string>(UserStorageKey).Result;
             string credentialKey = LocalSettingsWrapper.Instance.ReadSettingAsync<string>(CredentialStorageKey).Result;
+            if (storageKey == null || credentialKey == null)
+            {
+                return (null, null);
+            }
             var info = JsonConvert.DeserializeObject<UserInfo>(storageKey, this.options);
             var credential = JsonConvert.DeserializeObject<FirebaseCredential>(credentialKey, this.options);
 
@@ -49,7 +53,9 @@ namespace Firebase.Auth.Repository
 
         public bool UserExists()
         {
-            return LocalSettingsWrapper.Instance.Exists(UserStorageKey);
+            string storageKey = LocalSettingsWrapper.Instance.ReadSettingAsync<string>(UserStorageKey).Result;
+            return storageKey != null;
+            //return LocalSettingsWrapper.Instance.Exists(UserStorageKey);
             //return this.settings.Values.ContainsKey(UserStorageKey);
         }
     }


### PR DESCRIPTION
I have fixed an issue where calling ApplicationData.Current in a WinUI 3 environment running in Unpackaged Mode throws an InvalidOperationException.

![image](https://github.com/step-up-labs/firebase-authentication-dotnet/assets/51893532/9e548362-9c99-41b4-9f80-21fba28ba9ac)