### PR TITLE
Enable multitenancy  in Firebase.Auth project

### DIFF
--- a/src/Auth/AuthCredential.cs
+++ b/src/Auth/AuthCredential.cs
@@ -5,6 +5,7 @@
     /// </summary>
     public abstract class AuthCredential
     {
+        public string               TenantId     { get; set; }
         public FirebaseProviderType ProviderType { get; set; }
     }
 }

--- a/src/Auth/FirebaseAuthException.cs
+++ b/src/Auth/FirebaseAuthException.cs
@@ -40,14 +40,17 @@
     /// </summary>
     public class FirebaseAuthLinkConflictException : FirebaseAuthException
     {
-        public FirebaseAuthLinkConflictException(string email, IEnumerable<FirebaseProviderType> providers) 
-            : base($"An account already exists with the same email address but different sign-in credentials. Sign in using a provider associated with this email address: {email}", AuthErrorReason.AccountExistsWithDifferentCredential)
+        public FirebaseAuthLinkConflictException(string email, IEnumerable<FirebaseProviderType> providers, string tenantId = null)
+            : base($"An account already exists{(string.IsNullOrEmpty(tenantId) ? "" : $" in tenant {tenantId}")} with the same email address but different sign-in credentials. Sign in using a provider associated with this email address: {email}", AuthErrorReason.AccountExistsWithDifferentCredential)
         {
-            this.Email = email;
+            this.Email     = email;
             this.Providers = providers;
+            this.TenantId  = tenantId;
         }
 
         public string Email { get; }
+
+        public string TenantId { get; set; }
 
         public IEnumerable<FirebaseProviderType> Providers { get; }
     }

--- a/src/Auth/IFirebaseAuthClient.cs
+++ b/src/Auth/IFirebaseAuthClient.cs
@@ -22,29 +22,30 @@ namespace Firebase.Auth
         /// <summary>
         /// Gets a list of sign-in methods for given email. If there are no methods, it means the user with given email doesn't exist.
         /// </summary>
-        Task<FetchUserProvidersResult> FetchSignInMethodsForEmailAsync(string email);
+        Task<FetchUserProvidersResult> FetchSignInMethodsForEmailAsync(string email, string tenantId = null);
         
         /// <summary>
         /// Creates a new user with given email, password and display name (optional) and signs this user in.
         /// </summary>
-        Task<UserCredential> CreateUserWithEmailAndPasswordAsync(string email, string password, string displayName = null);
+        Task<UserCredential> CreateUserWithEmailAndPasswordAsync(string email, string password, string displayName = null, string tenantId = null);
         
         /// <summary>
         /// Signs in as an anonymous user.
         /// </summary>
-        Task<UserCredential> SignInAnonymouslyAsync();
+        Task<UserCredential> SignInAnonymouslyAsync(string tenantId = null);
 
         /// <summary>
         /// Signs in via third party OAuth providers - e.g. Google, Facebook etc.
         /// </summary>
         /// <param name="authType"> Type of the provider, must be an oauth one. </param>
         /// <param name="redirectDelegate"> Delegate which should invoke the passed uri for oauth authentication and return the final redirect uri. </param>
-        Task<UserCredential> SignInWithRedirectAsync(FirebaseProviderType authType, SignInRedirectDelegate redirectDelegate);
+        /// <param name="tenantId"> Optional tenant id..</param>
+        Task<UserCredential> SignInWithRedirectAsync(FirebaseProviderType authType, SignInRedirectDelegate redirectDelegate, string tenantId = null);
         
         /// <summary>
         /// Signs in with email and password. If the email &amp; password combination is incorrect, <see cref="FirebaseAuthException"/> is thrown.
         /// </summary>
-        Task<UserCredential> SignInWithEmailAndPasswordAsync(string email, string password);
+        Task<UserCredential> SignInWithEmailAndPasswordAsync(string email, string password, string tenantId = null);
 
         /// <summary>
         /// Sign in with platform specific credential. For example:
@@ -57,7 +58,7 @@ namespace Firebase.Auth
         /// <summary>
         /// Sends a password reset email to given address.
         /// </summary>
-        Task ResetEmailPasswordAsync(string email);
+        Task ResetEmailPasswordAsync(string email, string tenantId = null);
 
         /// <summary>
         /// Signs current user out.

--- a/src/Auth/Providers/AppleProvider.cs
+++ b/src/Auth/Providers/AppleProvider.cs
@@ -9,7 +9,7 @@
             this.AddScopes(DefaultEmailScope);
         }
 
-        public static AuthCredential GetCredential(string accessToken) => GetCredential(FirebaseProviderType.Apple, accessToken, OAuthCredentialTokenType.AccessToken);
+        public static AuthCredential GetCredential(string accessToken, string tenantId = null) => GetCredential(FirebaseProviderType.Apple, accessToken, tenantId, OAuthCredentialTokenType.AccessToken);
 
         public override FirebaseProviderType ProviderType => FirebaseProviderType.Apple;
 

--- a/src/Auth/Providers/EmailProvider.cs
+++ b/src/Auth/Providers/EmailProvider.cs
@@ -27,39 +27,42 @@ namespace Firebase.Auth.Providers
             this.linkAccount = new SetAccountLink(config);
         }
 
-        public static AuthCredential GetCredential(string email, string password)
+        public static AuthCredential GetCredential(string email, string password, string tenantId = null)
         {
             return new EmailCredential
             {
                 ProviderType = FirebaseProviderType.EmailAndPassword,
                 Email = email,
-                Password = password
+                Password = password,
+                TenantId = tenantId
             };
         }
 
-        public Task ResetEmailPasswordAsync(string email)
+        public Task ResetEmailPasswordAsync(string email, string tenantId = null)
         {
             var request = new ResetPasswordRequest
             {
-                Email = email
+                Email = email,
+                TenantId = tenantId
             };
 
             return this.resetPassword.ExecuteAsync(request);
         }
 
-        public Task<UserCredential> SignInUserAsync(string email, string password)
+        public Task<UserCredential> SignInUserAsync(string email, string password, string tenantId = null)
         {
-            return this.SignInWithCredentialAsync(GetCredential(email, password));
+            return this.SignInWithCredentialAsync(GetCredential(email, password, tenantId));
         }
 
-        public async Task<UserCredential> SignUpUserAsync(string email, string password, string displayName)
+        public async Task<UserCredential> SignUpUserAsync(string email, string password, string displayName, string tenantId = null)
         {
-            var authCredential = GetCredential(email, password);
+            var authCredential = GetCredential(email, password, tenantId);
             var signupResponse = await this.signupNewUser.ExecuteAsync(new SignupNewUserRequest
             {
                 Email = email,
                 Password = password,
-                ReturnSecureToken = true
+                ReturnSecureToken = true,
+                TenantId = tenantId
             }).ConfigureAwait(false);
 
             var credential = new FirebaseCredential
@@ -105,7 +108,8 @@ namespace Firebase.Auth.Providers
             {
                 Email = ec.Email,
                 Password = ec.Password,
-                ReturnSecureToken = true
+                ReturnSecureToken = true,
+                TenantId = ec.TenantId
             }).ConfigureAwait(false);
 
             var user = await this.GetUserInfoAsync(response.IdToken).ConfigureAwait(false);

--- a/src/Auth/Providers/FacebookProvider.cs
+++ b/src/Auth/Providers/FacebookProvider.cs
@@ -9,7 +9,7 @@
             this.AddScopes(DefaultEmailScope);
         }
 
-        public static AuthCredential GetCredential(string accessToken) => GetCredential(FirebaseProviderType.Facebook, accessToken, OAuthCredentialTokenType.AccessToken);
+        public static AuthCredential GetCredential(string accessToken, string tenantId = null) => GetCredential(FirebaseProviderType.Facebook, accessToken, tenantId, OAuthCredentialTokenType.AccessToken);
 
         public override FirebaseProviderType ProviderType => FirebaseProviderType.Facebook;
 

--- a/src/Auth/Providers/GithubProvider.cs
+++ b/src/Auth/Providers/GithubProvider.cs
@@ -2,7 +2,7 @@
 {
     public class GithubProvider : OAuthProvider
     {
-        public static AuthCredential GetCredential(string accessToken) => GetCredential(FirebaseProviderType.Github, accessToken, OAuthCredentialTokenType.AccessToken);
+        public static AuthCredential GetCredential(string accessToken, string tenantId = null) => GetCredential(FirebaseProviderType.Github, accessToken, tenantId, OAuthCredentialTokenType.AccessToken);
 
         public override FirebaseProviderType ProviderType => FirebaseProviderType.Github;
     }

--- a/src/Auth/Providers/GoogleProvider.cs
+++ b/src/Auth/Providers/GoogleProvider.cs
@@ -10,7 +10,7 @@
             this.AddScopes(DefaultProfileScope, DefaultEmailScope);
         }
 
-        public static AuthCredential GetCredential(string token, OAuthCredentialTokenType tokenType = OAuthCredentialTokenType.AccessToken) => GetCredential(FirebaseProviderType.Google, token, tokenType);
+        public static AuthCredential GetCredential(string token, OAuthCredentialTokenType tokenType = OAuthCredentialTokenType.AccessToken, string tenantId = null) => GetCredential(FirebaseProviderType.Google, token, tenantId, tokenType);
 
         public override FirebaseProviderType ProviderType => FirebaseProviderType.Google;
 

--- a/src/Auth/Providers/MicrosoftProvider.cs
+++ b/src/Auth/Providers/MicrosoftProvider.cs
@@ -15,7 +15,7 @@
             this.AddScopes(DefaultScopes);
         }
 
-        public static AuthCredential GetCredential(string accessToken) => GetCredential(FirebaseProviderType.Microsoft, accessToken, OAuthCredentialTokenType.AccessToken);
+        public static AuthCredential GetCredential(string accessToken, string tenantId = null) => GetCredential(FirebaseProviderType.Microsoft, accessToken, tenantId, OAuthCredentialTokenType.AccessToken);
 
         public override FirebaseProviderType ProviderType => FirebaseProviderType.Microsoft;
     }

--- a/src/Auth/Providers/OAuthContinuation.cs
+++ b/src/Auth/Providers/OAuthContinuation.cs
@@ -33,8 +33,9 @@ namespace Firebase.Auth.Providers
         /// </summary>
         /// <param name="redirectUri"> Final uri that user lands on after completing sign in in browser. </param>
         /// <param name="idToken"> Optional id token  of an existing Firebase user. If set, it will effectivelly perform account linking. </param>
+        /// <param name="tenantId"> Optional tenant id.</param>
         /// <returns></returns>
-        public async Task<UserCredential> ContinueSignInAsync(string redirectUri, string idToken = null)
+        public async Task<UserCredential> ContinueSignInAsync(string redirectUri, string idToken = null, string tenantId = null)
         {
             var (user, response) = await this.verifyAssertion.ExecuteAndParseAsync(
                 this.providerType, 
@@ -44,11 +45,12 @@ namespace Firebase.Auth.Providers
                     RequestUri = redirectUri,
                     SessionId = this.sessionId,
                     ReturnIdpCredential = true,
-                    ReturnSecureToken = true
+                    ReturnSecureToken = true,
+                    TenantId = tenantId
                 }).ConfigureAwait(false);
 
             var provider = this.config.GetAuthProvider(this.providerType) as OAuthProvider ?? throw new InvalidOperationException($"{this.providerType} is not a OAuthProvider");
-            var credential = provider.GetCredential(response);
+            var credential = provider.GetCredential(response, tenantId);
 
             response.Validate(credential);
 

--- a/src/Auth/Providers/TwitterProvider.cs
+++ b/src/Auth/Providers/TwitterProvider.cs
@@ -4,13 +4,14 @@ namespace Firebase.Auth.Providers
 {
     public class TwitterProvider : OAuthProvider
     {
-        public static AuthCredential GetCredential(string token, string secret)
+        public static AuthCredential GetCredential(string token, string secret, string tenantId)
         {
             return new TwitterCredential
             {
                 ProviderType = FirebaseProviderType.Twitter,
                 Token = token,
-                Secret = secret
+                Secret = secret,
+                TenantId = tenantId
             };
         }
 
@@ -18,9 +19,9 @@ namespace Firebase.Auth.Providers
 
         protected override string LocaleParameterName => "lang";
 
-        internal override AuthCredential GetCredential(VerifyAssertionResponse response)
+        internal override AuthCredential GetCredential(VerifyAssertionResponse response, string tenantId)
         {
-            return GetCredential(response.OauthAccessToken, response.OauthTokenSecret);
+            return GetCredential(response.OauthAccessToken, response.OauthTokenSecret, tenantId);
         }
 
         internal class TwitterCredential : OAuthCredential

--- a/src/Auth/Requests/CreateAuthUri.cs
+++ b/src/Auth/Requests/CreateAuthUri.cs
@@ -32,6 +32,8 @@ namespace Firebase.Auth.Requests
         public string OauthScope { get; set; }
 
         public string Identifier { get; set; }
+
+        public string TenantId { get; set; }
     }
 
     /// <summary>

--- a/src/Auth/Requests/ResetPassword.cs
+++ b/src/Auth/Requests/ResetPassword.cs
@@ -12,6 +12,8 @@
         public string Email { get; set; }
 
         public string RequestType { get; set; }
+
+        public string TenantId { get; set; }
     }
 
     public class ResetPasswordResponse

--- a/src/Auth/Requests/SignupNewUser.cs
+++ b/src/Auth/Requests/SignupNewUser.cs
@@ -6,7 +6,8 @@
 
         public string Password { get; set; }
 
-        public bool ReturnSecureToken { get; set; }
+        public bool   ReturnSecureToken { get; set; }
+        public string TenantId          { get; set; }
     }
 
     public class SignupNewUserResponse

--- a/src/Auth/Requests/VerifyAssertion.cs
+++ b/src/Auth/Requests/VerifyAssertion.cs
@@ -7,52 +7,53 @@ namespace Firebase.Auth.Requests
     public class VerifyAssertionRequest : IdTokenRequest
     {
         public string RequestUri { get; set; }
-        
+
         public string PostBody { get; set; }
-        
+
         public string PendingToken { get; set; }
 
         public string SessionId { get; set; }
 
         public bool ReturnIdpCredential { get; set; }
 
-        public bool ReturnSecureToken { get; set; }
+        public bool   ReturnSecureToken { get; set; }
+        public string TenantId          { get; set; }
     }
 
     public class VerifyAssertionResponse
     {
         public string FederatedId { get; set; }
-        
+
         public FirebaseProviderType ProviderId { get; set; }
-        
+
         public string Email { get; set; }
-        
+
         public bool EmailVerified { get; set; }
-        
+
         public string FirstName { get; set; }
-        
+
         public string FullName { get; set; }
-        
+
         public string LastName { get; set; }
-        
+
         public string PhotoUrl { get; set; }
-        
+
         public string LocalId { get; set; }
-        
+
         public string DisplayName { get; set; }
-        
+
         public string IdToken { get; set; }
-        
+
         public string Context { get; set; }
-        
+
         public string OauthAccessToken { get; set; }
-        
+
         public string OauthTokenSecret { get; set; }
-        
+
         public int OauthExpireIn { get; set; }
-        
+
         public string RefreshToken { get; set; }
-        
+
         public int ExpiresIn { get; set; }
 
         public string OauthIdToken { get; set; }
@@ -77,14 +78,15 @@ namespace Firebase.Auth.Requests
         public VerifyAssertion(FirebaseAuthConfig config) : base(config)
         {
         }
-        
+
         public static void ValidateAssertionResponse(VerifyAssertionResponse response, AuthCredential credential)
         {
             if (response.NeedConfirmation)
             {
                 throw new FirebaseAuthLinkConflictException(
                     response.Email,
-                    response.VerifiedProviders);
+                    response.VerifiedProviders,
+                    credential.TenantId);
             }
 
             if (response.ErrorMessage == "FEDERATED_USER_ID_ALREADY_LINKED")

--- a/src/Auth/Requests/VerifyPassword.cs
+++ b/src/Auth/Requests/VerifyPassword.cs
@@ -6,7 +6,8 @@
 
         public string Password { get; set; }
 
-        public bool ReturnSecureToken { get; set; }
+        public bool   ReturnSecureToken { get; set; }
+        public string TenantId          { get; set; }
     }
 
     public class VerifyPasswordResponse


### PR DESCRIPTION
I'm opening this draft to know if you are interested in support multitenancy.
I'have upated only the `Firebase.Auth` project, i'm not using UI and also dont have the winui3 and uwp sdk installed.

There are not "strict" breaking changes: the `tenantId` is an optional string. But even if its optional, people updating the nuget will be required to recompile their project (but this should not be a problem: if you are updating a nuget, then you'll likely recompile your project @ 😄 )

Some additional tests will be required, but for now everything seems working great (already using it in my app without problems).

For reference, i took the requests that have the `tenantId ` field in input from here:
https://developers.google.com/resources/api-libraries/documentation/identitytoolkit/v3/python/latest/identitytoolkit_v3.relyingparty.html#verifyAssertion

https://cloud.google.com/identity-platform/docs/use-rest-api?hl=it#section-confirm-email-verification

